### PR TITLE
Use omeroweb.webclient.decorators rather than omeroweb.webstart.decorators

### DIFF
--- a/weberror/views.py
+++ b/weberror/views.py
@@ -29,7 +29,7 @@ from django.views.decorators.cache import never_cache
 
 from omero_version import omero_version
 
-from omeroweb.webstart.decorators import login_required, render_response
+from omeroweb.webclient.decorators import login_required, render_response
 
 @never_cache
 @login_required()


### PR DESCRIPTION
This should should restore the compatibility of the weberror OMERO.web app
with the 5.0.x line of OMERO.web and simplify deployment on the CI
infrastructure.

/cc @aleksandra-tarkowska 