### PR TITLE
add warning test view

### DIFF
--- a/weberror/urls.py
+++ b/weberror/urls.py
@@ -30,4 +30,5 @@ urlpatterns = patterns(
     '',
     url(r'^error_404/$', views.error404, name="weberror404"),
     url(r'^error_500/$', views.error500, name="weberror500"),
+    url(r'^warning/$', views.warning, name="warning"),
 )

--- a/weberror/views.py
+++ b/weberror/views.py
@@ -24,7 +24,7 @@
 #
 import logging
 
-from django.http import Http404, HttpResponse
+from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 
 from omero_version import omero_version
@@ -32,6 +32,7 @@ from omero_version import omero_version
 from omeroweb.webclient.decorators import login_required, render_response
 
 logger = logging.getLogger(__name__)
+
 
 @never_cache
 @login_required()
@@ -51,9 +52,11 @@ def error500(request, conn=None, **kwargs):
     context['template'] = view_raise_500  # noqa
     return context  # noqa
 
+
 @never_cache
 @render_response()
 def warning(request, conn=None, **kwargs):
+    logger.info("This view writes warnings into the logfile.")
     # it is intentional that this view log py.warnings
-    val = request.REQUEST.get("foo", None)
+    request.REQUEST.get("foo", None)
     return HttpResponse('This is warning in a logfile')

--- a/weberror/views.py
+++ b/weberror/views.py
@@ -59,4 +59,4 @@ def warning(request, conn=None, **kwargs):
     logger.info("This view writes warnings into the logfile.")
     # it is intentional that this view log py.warnings
     request.REQUEST.get("foo", None)
-    return HttpResponse('This is warning in a logfile')
+    return HttpResponse('Django 1.8+ This view creates warning in a logfile.')

--- a/weberror/views.py
+++ b/weberror/views.py
@@ -22,13 +22,16 @@
 #
 # Version: 1.0
 #
+import logging
 
+from django.http import Http404, HttpResponse
 from django.views.decorators.cache import never_cache
 
 from omero_version import omero_version
 
 from omeroweb.webclient.decorators import login_required, render_response
 
+logger = logging.getLogger(__name__)
 
 @never_cache
 @login_required()
@@ -47,3 +50,10 @@ def error500(request, conn=None, **kwargs):
     # it is intentional that this view raise and error
     context['template'] = view_raise_500  # noqa
     return context  # noqa
+
+@never_cache
+@render_response()
+def warning(request, conn=None, **kwargs):
+    # it is intentional that this view log py.warnings
+    val = request.REQUEST.get("foo", None)
+    return HttpResponse('This is warning in a logfile')


### PR DESCRIPTION
This helps to test py.warning

To test:
 - go to weberror/warning/
 - check if OMEROweb.log contains:

 ```
2015-10-07 09:16:50,904 WARNI [                             py.warnings] (proc.00890) _get_request:124 weberror/views.py:58: RemovedInDjango19Warning: `request.REQUEST` is deprecated, use `request.GET` or `request.POST` instead.
  val = request.REQUEST.get("foo", "default")
2015-10-07 09:16:50,905 WARNI [                             py.warnings] (proc.00890) __init__:19 /Library/Python/2.7/site-packages/django/core/handlers/wsgi.py:126: RemovedInDjango19Warning: `MergeDict` is deprecated, use `dict.update()` instead.
  self._request = datastructures.MergeDict(self.POST, self.GET)
 ```

cc: @sbesson 